### PR TITLE
basic code flow

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -420,6 +420,7 @@ public final class DBStoreBuilder {
     // Apply WAL settings.
     dbOptions.setWalTtlSeconds(rocksDBConfiguration.getWalTTL());
     dbOptions.setWalSizeLimitMB(rocksDBConfiguration.getWalSizeLimit());
+    dbOptions.setManualWalFlush(true);
 
     return dbOptions;
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -327,6 +327,10 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    * @throws IOException
    */
   void loadFromFile(File externalFile) throws IOException;
+  
+  default Table getRawTable() {
+    return this;
+  }
 
   /**
    * Class used to represent the key and value pair of a db entry.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -228,6 +228,10 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
     throw new NotImplementedException("cleanupCache is not implemented");
   }
 
+  default void resetCache(byte[] encodedKey, long epoch) throws IOException {
+    throw new NotImplementedException("reset cache is not implemented");
+  }
+
   /**
    * Return cache iterator maintained for this table.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -542,7 +542,10 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   public void loadFromFile(File externalFile) throws IOException {
     rawTable.loadFromFile(externalFile);
   }
-
+  @Override
+  public Table getRawTable() {
+    return rawTable;
+  }
   @Override
   public void cleanupCache(List<Long> epochs) {
     cache.cleanup(epochs);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.hdds.utils.IOUtils;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.TableCacheMetrics;
@@ -483,6 +484,20 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   @Override
   public TableCacheMetrics createCacheMetrics() {
     return TableCacheMetrics.create(cache, getName());
+  }
+
+  @Override
+  public void resetCache(byte[] encodedKey, long epoch) throws IOException {
+    if (cache.getCacheType() != CacheType.FULL_CACHE) {
+      return;
+    }
+    KEY key = decodeKey(encodedKey);
+    VALUE val = getSkipCache(key);
+    if (val != null) {
+      addCacheEntry(key, val, epoch);
+    } else {
+      addCacheEntry(key, epoch);
+    }
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
@@ -129,6 +129,20 @@ public class FullTableCache<KEY, VALUE> implements TableCache<KEY, VALUE> {
   }
 
   @Override
+  public void reset(CacheKey<KEY> cacheKey, CacheValue<VALUE> value) {
+    lock.writeLock().lock();
+    try {
+      CacheValue<VALUE> cacheValue = cache.get(cacheKey);
+      if (cacheValue.getEpoch() > value.getEpoch()) {
+        return;
+      }
+      cache.put(cacheKey, value);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
   public void cleanup(List<Long> epochs) {
     epochCleanupQueue.clear();
     epochCleanupQueue.addAll(epochs);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -65,6 +65,14 @@ public interface TableCache<KEY, VALUE> {
    */
   void cleanup(List<Long> epochs);
 
+  /**
+   * reset cache value with new value provided if new epoch is later or equal to current epoch.
+   * @param cacheKey
+   * @param value
+   */
+  default void reset(CacheKey<KEY> cacheKey, CacheValue<VALUE> value) {
+  }
+
   @VisibleForTesting
   void evictCache(List<Long> epochs);
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStreamSemaphore.java
@@ -32,7 +32,7 @@ public class KeyOutputStreamSemaphore {
   private final Semaphore requestSemaphore;
 
   KeyOutputStreamSemaphore(int maxConcurrentWritePerKey) {
-    LOG.info("Initializing semaphore with maxConcurrentWritePerKey = {}", maxConcurrentWritePerKey);
+    //LOG.info("Initializing semaphore with maxConcurrentWritePerKey = {}", maxConcurrentWritePerKey);
     if (maxConcurrentWritePerKey > 0) {
       requestSemaphore = new Semaphore(maxConcurrentWritePerKey);
     } else if (maxConcurrentWritePerKey == 0) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -327,7 +327,8 @@ public final class OmUtils {
     case SetTimes:
     case AbortExpiredMultiPartUploads:
     case SetSnapshotProperty:
-    case QuotaRepair:
+    case QuotaRepair: 
+    case PersistDb:
     case UnknownCommand:
       return false;
     case EchoRPC:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -188,13 +188,13 @@ public class OzoneManagerLock implements IOzoneManagerLock {
     long startWaitingTimeNanos = Time.monotonicNowNanos();
 
     ReentrantReadWriteLock lock = getLock(resource, keys);
-    if (isReadLock) {
-      lock.readLock().lock();
-      updateReadLockMetrics(resource, lock, startWaitingTimeNanos);
-    } else {
-      lock.writeLock().lock();
-      updateWriteLockMetrics(resource, lock, startWaitingTimeNanos);
-    }
+    //if (isReadLock) {
+      //lock.readLock().lock();
+      //updateReadLockMetrics(resource, lock, startWaitingTimeNanos);
+    //} else {
+      //lock.writeLock().lock();
+      //updateWriteLockMetrics(resource, lock, startWaitingTimeNanos);
+    //}
 
     lockSet.set(resource.setLock(lockSet.get()));
     omLockDetails.get().setLockAcquired(true);
@@ -337,15 +337,15 @@ public class OzoneManagerLock implements IOzoneManagerLock {
   private OMLockDetails releaseLock(Resource resource, boolean isReadLock,
       String... keys) {
     omLockDetails.get().clear();
-    ReentrantReadWriteLock lock = getLock(resource, keys);
-    if (isReadLock) {
-      lock.readLock().unlock();
-      updateReadUnlockMetrics(resource, lock);
-    } else {
-      boolean isWriteLocked = lock.isWriteLockedByCurrentThread();
-      lock.writeLock().unlock();
-      updateWriteUnlockMetrics(resource, lock, isWriteLocked);
-    }
+    //ReentrantReadWriteLock lock = getLock(resource, keys);
+    //if (isReadLock) {
+    //  lock.readLock().unlock();
+    //  updateReadUnlockMetrics(resource, lock);
+    //} else {
+    //  boolean isWriteLocked = lock.isWriteLockedByCurrentThread();
+    //  lock.writeLock().unlock();
+    //  updateWriteUnlockMetrics(resource, lock, isWriteLocked);
+    //}
 
     lockSet.set(resource.clearLock(lockSet.get()));
     return omLockDetails.get();

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -149,6 +149,7 @@ enum Type {
   RenameSnapshot = 131;
   ListOpenFiles = 132;
   QuotaRepair = 133;
+  PersistDb = 134;
 }
 
 enum SafeMode {
@@ -287,6 +288,7 @@ message OMRequest {
   optional RenameSnapshotRequest            RenameSnapshotRequest          = 129;
   optional ListOpenFilesRequest             ListOpenFilesRequest           = 130;
   optional QuotaRepairRequest               QuotaRepairRequest             = 131;
+  optional PersistDbRequest                 PersistDbRequest               = 132;
 }
 
 message OMResponse {
@@ -412,6 +414,7 @@ message OMResponse {
   optional RenameSnapshotResponse            RenameSnapshotResponse        = 132;
   optional ListOpenFilesResponse             ListOpenFilesResponse         = 133;
   optional QuotaRepairResponse            QuotaRepairResponse        = 134;
+  optional PersistDbResponse            PersistDbResponse        = 135;
 }
 
 enum Status {
@@ -2202,6 +2205,20 @@ message BucketQuotaCount {
 message QuotaRepairResponse {
 }
 
+message PersistDbRequest {
+    repeated DBTableUpdate tableUpdates = 1;
+    required int64 cacheIndex = 2;
+}
+message DBTableUpdate {
+    required string tableName = 1;
+    repeated DBTableRecord records = 2;
+}
+message DBTableRecord {
+    required bytes key = 1;
+    optional bytes value = 2;
+}
+message PersistDbResponse {
+}
 message OMLockDetailsProto {
   optional bool isLockAcquired = 1;
   optional uint64 waitLockNanos    = 2;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -873,4 +873,8 @@ public final class OzoneManagerRatisServer {
     GrpcTlsConfig config = createServerTlsConfig(conf, caClient);
     return config == null ? null : RatisHelper.setServerTlsConf(config);
   }
+
+  public OzoneManagerRequestExecutor getOmRequestExecutor() {
+    return omRequestExecutor;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRequestExecutor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRequestExecutor.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.lock.OMLockDetails;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler;
+import org.apache.hadoop.ozone.protocolPB.RequestHandler;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.concurrent.HadoopExecutors;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The OM StateMachine is the state machine for OM Ratis server. It is
+ * responsible for applying ratis committed transactions to
+ * {@link OzoneManager}.
+ */
+public class OzoneManagerRequestExecutor {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(OzoneManagerRequestExecutor.class);
+  private final SimpleStateMachineStorage storage =
+      new SimpleStateMachineStorage();
+  private final OzoneManager ozoneManager;
+  private RequestHandler handler;
+  private final ExecutorService executorService;
+  private final String threadPrefix;
+  private final AtomicLong cacheIndex = new AtomicLong();
+
+  public OzoneManagerRequestExecutor(OzoneManagerRatisServer ratisServer) throws IOException {
+    this.ozoneManager = ratisServer.getOzoneManager();
+    this.threadPrefix = ozoneManager.getThreadNamePrefix();
+
+    this.handler = new OzoneManagerRequestHandler(ozoneManager);
+
+    ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
+        .setNameFormat(threadPrefix +
+            "OMStateMachineApplyTransactionThread - %d").build();
+    this.executorService = HadoopExecutors.newSingleThreadExecutor(build);
+  }
+
+  /**
+   * Validate the incoming update request.
+   * @throws IOException when validation fails
+   */
+  public void validate(OMRequest omRequest) throws IOException {
+    handler.validateRequest(omRequest);
+
+    // validate prepare state
+    OzoneManagerProtocolProtos.Type cmdType = omRequest.getCmdType();
+    OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
+    if (cmdType == OzoneManagerProtocolProtos.Type.Prepare) {
+      // Must authenticate prepare requests here, since we must determine
+      // whether or not to apply the prepare gate before proceeding with the
+      // prepare request.
+      UserGroupInformation userGroupInformation =
+          UserGroupInformation.createRemoteUser(
+              omRequest.getUserInfo().getUserName());
+      if (ozoneManager.getAclsEnabled()
+          && !ozoneManager.isAdmin(userGroupInformation)) {
+        String message = "Access denied for user " + userGroupInformation
+            + ". "
+            + "Superuser privilege is required to prepare ozone managers.";
+        throw new OMException(message, OMException.ResultCodes.ACCESS_DENIED);
+      } else {
+        prepareState.enablePrepareGate();
+      }
+    }
+
+    // In prepare mode, only prepare and cancel requests are allowed to go
+    // through.
+    if (!prepareState.requestAllowed(cmdType)) {
+      String message = "Cannot apply write request " +
+          omRequest.getCmdType().name() + " when OM is in prepare mode.";
+      throw new OMException(message,
+          OMException.ResultCodes.NOT_SUPPORTED_OPERATION_WHEN_PREPARED);
+    }
+  }
+
+  /*
+   * Apply a committed log entry to the state machine.
+   */
+  public CompletableFuture<OMResponse> submit(OMRequest omRequest) {
+    // TODO: throttling max number of request
+    try {
+      return CompletableFuture.supplyAsync(() -> runCommand(omRequest), executorService);
+    } catch (Exception e) {
+      return completeExceptionally(e);
+    }
+  }
+
+  /**
+   * Submits write request to OM and returns the response Message.
+   * @param request OMRequest
+   * @return response from OM
+   */
+  private OMResponse runCommand(OMRequest request) {
+    try {
+      validate(request);
+      // TODO term Index consistency in HA
+      TermIndex termIndex = TermIndex.valueOf(1, cacheIndex.incrementAndGet());
+      LOG.warn("sumit..start...{}--{}", request.getCmdType().name(), cacheIndex.get());
+      final OMClientResponse omClientResponse = handler.handleWriteRequestImpl(request, termIndex);
+      OMLockDetails omLockDetails = omClientResponse.getOmLockDetails();
+      OMResponse omResponse = omClientResponse.getOMResponse();
+      if (omResponse.getSuccess()) {
+        OMResponse dbUpdateRsp = applyDbUpdateViaRatis(request, termIndex, omClientResponse);
+        if (dbUpdateRsp != null) {
+          // in case of failure, return db update failure response
+          return dbUpdateRsp;
+        }
+      }
+      if (omLockDetails != null) {
+        return omResponse.toBuilder().setOmLockDetails(omLockDetails.toProtobufBuilder()).build();
+      } else {
+        return omResponse;
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to write, Exception occurred ", e);
+      return createErrorResponse(request, e);
+    } catch (Throwable e) {
+      LOG.warn("Failed to write, Exception occurred ", e);
+      return createErrorResponse(request, new IOException(e));
+    } finally {
+      LOG.warn("sumit..end...{}--{}", request.getCmdType().name(), cacheIndex.get());
+    }
+  }
+
+  @Nullable
+  private OMResponse applyDbUpdateViaRatis(OMRequest request, TermIndex termIndex, OMClientResponse omClientResponse)
+      throws IOException, ServiceException {
+    try (BatchOperation batchOperation = ozoneManager.getMetadataManager().getStore()
+        .initBatchOperation()) {
+      omClientResponse.checkAndUpdateDB(ozoneManager.getMetadataManager(), batchOperation);
+      // get db update and raise request to flush
+      OzoneManagerProtocolProtos.PersistDbRequest.Builder reqBuilder
+          = OzoneManagerProtocolProtos.PersistDbRequest.newBuilder();
+      Map<String, Map<byte[], byte[]>> cachedDbTxs = ((RDBBatchOperation) batchOperation).getCachedTransaction();
+      for (Map.Entry<String, Map<byte[], byte[]>> tblEntry : cachedDbTxs.entrySet()) {
+        OzoneManagerProtocolProtos.DBTableUpdate.Builder tblBuilder
+            = OzoneManagerProtocolProtos.DBTableUpdate.newBuilder();
+        tblBuilder.setTableName(tblEntry.getKey());
+        for (Map.Entry<byte[], byte[]> kvEntry : tblEntry.getValue().entrySet()) {
+          OzoneManagerProtocolProtos.DBTableRecord.Builder kvBuild
+              = OzoneManagerProtocolProtos.DBTableRecord.newBuilder();
+          kvBuild.setKey(ByteString.copyFrom(kvEntry.getKey()));
+          if (kvEntry.getValue() != null) {
+            kvBuild.setValue(ByteString.copyFrom(kvEntry.getValue()));
+          }
+          tblBuilder.addRecords(kvBuild.build());
+        }
+        reqBuilder.addTableUpdates(tblBuilder.build());
+      }
+      reqBuilder.setCacheIndex(termIndex.getIndex());
+      OMRequest.Builder omReqBuilder = OMRequest.newBuilder().setPersistDbRequest(reqBuilder.build())
+          .setCmdType(OzoneManagerProtocolProtos.Type.PersistDb).setClientId(request.getClientId());
+      OMResponse response = ozoneManager.getOmRatisServer().submitRequest(omReqBuilder.build());
+      if (!response.getSuccess()) {
+        // Do update to DB failure need crash OM?
+        return response;
+      }
+    }
+    return null;
+  }
+
+  private OMResponse createErrorResponse(OMRequest omRequest, IOException exception) {
+    OMResponse.Builder omResponseBuilder = OMResponse.newBuilder()
+        .setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(exception))
+        .setCmdType(omRequest.getCmdType())
+        .setTraceID(omRequest.getTraceID())
+        .setSuccess(false);
+    if (exception.getMessage() != null) {
+      omResponseBuilder.setMessage(exception.getMessage());
+    }
+    OMResponse omResponse = omResponseBuilder.build();
+    return omResponse;
+  }
+
+  private static <T> CompletableFuture<T> completeExceptionally(Exception e) {
+    final CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(e);
+    return future;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRequestExecutor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRequestExecutor.java
@@ -19,14 +19,20 @@ package org.apache.hadoop.ozone.om.ratis;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.ServiceException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -41,9 +47,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler;
 import org.apache.hadoop.ozone.protocolPB.RequestHandler;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,13 +60,12 @@ public class OzoneManagerRequestExecutor {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerRequestExecutor.class);
-  private final SimpleStateMachineStorage storage =
-      new SimpleStateMachineStorage();
   private final OzoneManager ozoneManager;
   private RequestHandler handler;
-  private final ExecutorService executorService;
   private final String threadPrefix;
   private final AtomicLong cacheIndex = new AtomicLong();
+  private final AtomicLong currentTerm = new AtomicLong(1);
+  private final ExecutorPipeline[] executorPipelines;
 
   public OzoneManagerRequestExecutor(OzoneManagerRatisServer ratisServer) throws IOException {
     this.ozoneManager = ratisServer.getOzoneManager();
@@ -73,7 +76,9 @@ public class OzoneManagerRequestExecutor {
     ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
         .setNameFormat(threadPrefix +
             "OMStateMachineApplyTransactionThread - %d").build();
-    this.executorService = HadoopExecutors.newSingleThreadExecutor(build);
+    executorPipelines = new ExecutorPipeline[2];
+    executorPipelines[0] = new ExecutorPipeline(10, this::runExecuteCommand);
+    executorPipelines[1] = new ExecutorPipeline(1, this::dbUpdateBatchCommand);
   }
 
   /**
@@ -118,53 +123,154 @@ public class OzoneManagerRequestExecutor {
    * Apply a committed log entry to the state machine.
    */
   public CompletableFuture<OMResponse> submit(OMRequest omRequest) {
-    // TODO: throttling max number of request
+    RequestContext requestContext = new RequestContext();
+    requestContext.setRequest(omRequest);
+    requestContext.setFuture(new CompletableFuture<>());
     try {
-      return CompletableFuture.supplyAsync(() -> runCommand(omRequest), executorService);
-    } catch (Exception e) {
-      return completeExceptionally(e);
+      String distributionKey = getDistributionKey(omRequest, ozoneManager);
+      int idx = Math.abs(distributionKey.hashCode() % 10);
+      //LOG.warn("sumit..entry...{}-{}-{}", omRequest.getCmdType().name(), distributionKey, idx);
+      executorPipelines[0].submit(idx, requestContext);
+    } catch (InterruptedException e) {
+      requestContext.getFuture().completeExceptionally(e);
+      Thread.currentThread().interrupt();
     }
+    return requestContext.getFuture();
   }
 
-  /**
-   * Submits write request to OM and returns the response Message.
-   * @param request OMRequest
-   * @return response from OM
-   */
-  private OMResponse runCommand(OMRequest request) {
+  private void runExecuteCommand(Collection<RequestContext> ctxs) {
+    for (RequestContext ctx : ctxs) {
+      executeRequest(ctx);
+    }
+  }
+  private void executeRequest(RequestContext ctx) {
+    OMRequest request = ctx.getRequest();
+    TermIndex termIndex = TermIndex.valueOf(currentTerm.get(), cacheIndex.incrementAndGet());
+    ctx.setCacheIndex(termIndex);
     try {
       validate(request);
-      // TODO term Index consistency in HA
-      TermIndex termIndex = TermIndex.valueOf(1, cacheIndex.incrementAndGet());
-      LOG.warn("sumit..start...{}--{}", request.getCmdType().name(), cacheIndex.get());
+      LOG.warn("sumit..start...{}--{}", request.getCmdType().name(), termIndex.getIndex());
       final OMClientResponse omClientResponse = handler.handleWriteRequestImpl(request, termIndex);
       OMLockDetails omLockDetails = omClientResponse.getOmLockDetails();
       OMResponse omResponse = omClientResponse.getOMResponse();
-      if (omResponse.getSuccess()) {
-        OMResponse dbUpdateRsp = applyDbUpdateViaRatis(request, termIndex, omClientResponse);
-        if (dbUpdateRsp != null) {
-          // in case of failure, return db update failure response
-          return dbUpdateRsp;
-        }
-      }
       if (omLockDetails != null) {
-        return omResponse.toBuilder().setOmLockDetails(omLockDetails.toProtobufBuilder()).build();
-      } else {
-        return omResponse;
+        omResponse = omResponse.toBuilder().setOmLockDetails(omLockDetails.toProtobufBuilder()).build();
+      }
+      ctx.setResponse(omResponse);
+      if (omResponse.getSuccess()) {
+        OMRequest nextRequest = prepareDBupdateRequest(request, termIndex, omClientResponse);
+        if (nextRequest != null) {
+          ctx.setNextRequest(nextRequest);
+        }
       }
     } catch (IOException e) {
       LOG.warn("Failed to write, Exception occurred ", e);
-      return createErrorResponse(request, e);
+      ctx.setResponse(createErrorResponse(request, e));
     } catch (Throwable e) {
       LOG.warn("Failed to write, Exception occurred ", e);
-      return createErrorResponse(request, new IOException(e));
+      ctx.setResponse(createErrorResponse(request, new IOException(e)));
     } finally {
-      LOG.warn("sumit..end...{}--{}", request.getCmdType().name(), cacheIndex.get());
+      LOG.warn("sumit..end...{}--{}", request.getCmdType().name(), termIndex.getIndex());
+      if (ctx.getNextRequest() != null) {
+        try {
+          executorPipelines[1].submit(0, ctx);
+          return;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      ctx.getFuture().complete(ctx.getResponse());
     }
   }
 
-  private OMResponse applyDbUpdateViaRatis(OMRequest request, TermIndex termIndex, OMClientResponse omClientResponse)
-      throws IOException, ServiceException {
+  private void dbUpdateBatchCommand(Collection<RequestContext> ctxs) {
+    OzoneManagerProtocolProtos.PersistDbRequest.Builder reqBuilder
+        = OzoneManagerProtocolProtos.PersistDbRequest.newBuilder();
+    int count = ctxs.size();
+    for (RequestContext ctx : ctxs) {
+      //LOG.warn("sumit..start.DB.{}-{}", ctx.getRequest().getCmdType().name(), ctx.getCacheIndex().getIndex());
+      OMRequest nextRequest = ctx.getNextRequest();
+      for (OzoneManagerProtocolProtos.DBTableUpdate tblUpdates
+          : nextRequest.getPersistDbRequest().getTableUpdatesList()) {
+        OzoneManagerProtocolProtos.DBTableUpdate.Builder tblBuilder
+            = OzoneManagerProtocolProtos.DBTableUpdate.newBuilder();
+        tblBuilder.setTableName(tblUpdates.getTableName());
+        tblBuilder.addAllRecords(tblUpdates.getRecordsList());
+        reqBuilder.addTableUpdates(tblBuilder.build());
+      }
+      // TODO based on size of request, need merge, test purpose, add all
+      --count;
+      if (count == 0) {
+        reqBuilder.setCacheIndex(nextRequest.getPersistDbRequest().getCacheIndex());
+        OMRequest.Builder omReqBuilder = OMRequest.newBuilder().setPersistDbRequest(reqBuilder.build())
+            .setCmdType(OzoneManagerProtocolProtos.Type.PersistDb).setClientId(nextRequest.getClientId());
+        
+        try {
+          OMResponse dbUpdateRsp = sendDbUpdateRequest(omReqBuilder.build(), ctx.getCacheIndex());
+          if (dbUpdateRsp != null) {
+            for (RequestContext repCtx : ctxs) {
+              repCtx.getFuture().complete(dbUpdateRsp);
+            }
+            continue;
+          }
+          for (RequestContext repCtx : ctxs) {
+            LOG.warn("sumit..end.DB.{}-{}", repCtx.getRequest().getCmdType().name(), repCtx.getCacheIndex().getIndex());
+            repCtx.getFuture().complete(repCtx.getResponse());
+          }
+        } catch (IOException e) {
+          LOG.warn("Failed to write, Exception occurred ", e);
+          for (RequestContext repCtx : ctxs) {
+            LOG.warn("sumit..end.DB.Fail.{}-{}", repCtx.getRequest().getCmdType().name(), repCtx.getCacheIndex().getIndex());
+            repCtx.getFuture().complete(createErrorResponse(ctx.getRequest(), e));
+          }
+        } catch (Throwable e) {
+          LOG.warn("Failed to write, Exception occurred ", e);
+          for (RequestContext repCtx : ctxs) {
+            LOG.warn("sumit..end.DB.Fail.{}-{}", repCtx.getRequest().getCmdType().name(), repCtx.getCacheIndex().getIndex());
+            repCtx.getFuture().complete(createErrorResponse(ctx.getRequest(), new IOException(e)));
+
+          }
+        }
+      }
+    }
+  }
+  private void dbUpdate(RequestContext ctx) {
+    OMResponse finalResponse = ctx.getResponse();
+    try {
+      OMResponse dbUpdateRsp = sendDbUpdateRequest(ctx.getNextRequest(), ctx.getCacheIndex());
+      if (dbUpdateRsp != null) {
+        // in case of failure, return db update failure response
+        finalResponse = dbUpdateRsp;
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to write, Exception occurred ", e);
+      finalResponse = createErrorResponse(ctx.getRequest(), e);
+    } catch (Throwable e) {
+      LOG.warn("Failed to write, Exception occurred ", e);
+      finalResponse = createErrorResponse(ctx.getRequest(), new IOException(e));
+    }
+    ctx.getFuture().complete(finalResponse);
+  }
+
+  private OMResponse sendDbUpdateRequest(OMRequest nextRequest, TermIndex termIndex) throws Exception {
+    try {
+      OMResponse response = ozoneManager.getOmRatisServer().submitRequest(nextRequest, termIndex.getIndex());
+      if (!response.getSuccess()) {
+        // TODO: retry on failure for db operation, otherwise next operation may have incorrect value
+        // if retry fails, need reject all request in all queue, and restart
+        refreshCache(ozoneManager, termIndex.getIndex(), nextRequest.getPersistDbRequest().getTableUpdatesList());
+        return response;
+      }
+    } catch (Exception ex) {
+      // TODO: retry on failure for db operation, otherwise next operation may have incorrect value
+      // if retry fails, need reject all request in all queue, and restart handler.
+      refreshCache(ozoneManager, termIndex.getIndex(), nextRequest.getPersistDbRequest().getTableUpdatesList());
+      throw ex;
+    }
+    return null;
+  }
+  private OMRequest prepareDBupdateRequest(OMRequest request, TermIndex termIndex, OMClientResponse omClientResponse)
+      throws IOException {
     try (BatchOperation batchOperation = ozoneManager.getMetadataManager().getStore()
         .initBatchOperation()) {
       omClientResponse.checkAndUpdateDB(ozoneManager.getMetadataManager(), batchOperation);
@@ -190,35 +296,30 @@ public class OzoneManagerRequestExecutor {
       reqBuilder.setCacheIndex(termIndex.getIndex());
       OMRequest.Builder omReqBuilder = OMRequest.newBuilder().setPersistDbRequest(reqBuilder.build())
           .setCmdType(OzoneManagerProtocolProtos.Type.PersistDb).setClientId(request.getClientId());
-      try {
-        OMResponse response = ozoneManager.getOmRatisServer().submitRequest(omReqBuilder.build());
-        if (!response.getSuccess()) {
-          refreshCache(termIndex.getIndex(), cachedDbTxs);
-          return response;
-        }
-      } catch (Exception ex) {
-        refreshCache(termIndex.getIndex(), cachedDbTxs);
-        throw ex;
-      }
+      return omReqBuilder.build();
     }
-    return null;
   }
 
-  private void refreshCache(long index, Map<String, Map<byte[], byte[]>> cachedDbTxs) throws IOException {
-    String bucketTableName = ozoneManager.getMetadataManager().getBucketTable().getName();
-    String volTableName = ozoneManager.getMetadataManager().getVolumeTable().getName();
-    for (Map.Entry<String, Map<byte[], byte[]>> tblEntry : cachedDbTxs.entrySet()) {
-      if (tblEntry.getKey().equals(bucketTableName)) {
-        for (byte[] keyName : tblEntry.getValue().keySet()) {
-          ozoneManager.getMetadataManager().getBucketTable().resetCache(keyName, index);
+  private void refreshCache(
+      OzoneManager om, long index, List<OzoneManagerProtocolProtos.DBTableUpdate> tableUpdatesList)
+      throws IOException {
+    String bucketTableName = om.getMetadataManager().getBucketTable().getName();
+    String volTableName = om.getMetadataManager().getVolumeTable().getName();
+    for (OzoneManagerProtocolProtos.DBTableUpdate tblUpdates : tableUpdatesList) {
+      if (tblUpdates.getTableName().equals(bucketTableName)) {
+        List<OzoneManagerProtocolProtos.DBTableRecord> recordsList = tblUpdates.getRecordsList();
+        for (OzoneManagerProtocolProtos.DBTableRecord record : recordsList) {
+          om.getMetadataManager().getBucketTable().resetCache(record.getKey().toByteArray(), index);
         }
       }
-      if (tblEntry.getKey().equals(volTableName)) {
-        for (byte[] keyName : tblEntry.getValue().keySet()) {
-          ozoneManager.getMetadataManager().getVolumeTable().resetCache(keyName, index);
+      if (tblUpdates.getTableName().equals(volTableName)) {
+        List<OzoneManagerProtocolProtos.DBTableRecord> recordsList = tblUpdates.getRecordsList();
+        for (OzoneManagerProtocolProtos.DBTableRecord record : recordsList) {
+          om.getMetadataManager().getVolumeTable().resetCache(record.getKey().toByteArray(), index);
         }
       }
-      ozoneManager.getMetadataManager().getTable(tblEntry.getKey()).cleanupCache(Collections.singletonList(index));
+      om.getMetadataManager().getTable(tblUpdates.getTableName())
+          .cleanupCache(Collections.singletonList(index));
     }
   }
 
@@ -235,14 +336,242 @@ public class OzoneManagerRequestExecutor {
     return omResponse;
   }
 
-  private static <T> CompletableFuture<T> completeExceptionally(Exception e) {
-    final CompletableFuture<T> future = new CompletableFuture<>();
-    future.completeExceptionally(e);
-    return future;
-  }
-
   public void notifyTermIndex(TermIndex termIndex) {
     long lastIdx = cacheIndex.get();
     cacheIndex.set(termIndex.getIndex() > lastIdx ? termIndex.getIndex() : lastIdx);
+    currentTerm.set(termIndex.getTerm());
+  }
+
+  /**
+   * request context.
+   */
+  public static final class RequestContext {
+    private OMRequest request;
+    private OMResponse response;
+    private TermIndex cacheIndex;
+    private CompletableFuture<OMResponse> future;
+    private OMRequest nextRequest;
+
+    private RequestContext() {
+    }
+
+    public OMRequest getRequest() {
+      return request;
+    }
+
+    public void setRequest(OMRequest request) {
+      this.request = request;
+    }
+
+    public OMResponse getResponse() {
+      return response;
+    }
+
+    public void setResponse(OMResponse response) {
+      this.response = response;
+    }
+
+    public TermIndex getCacheIndex() {
+      return cacheIndex;
+    }
+
+    public void setCacheIndex(TermIndex cacheIndex) {
+      this.cacheIndex = cacheIndex;
+    }
+
+    public CompletableFuture<OMResponse> getFuture() {
+      return future;
+    }
+
+    public void setFuture(CompletableFuture<OMResponse> future) {
+      this.future = future;
+    }
+
+    public OMRequest getNextRequest() {
+      return nextRequest;
+    }
+
+    public void setNextRequest(OMRequest nextRequest) {
+      this.nextRequest = nextRequest;
+    }
+  }
+
+  /**
+   * Executor pipeline.
+   */
+  public static class ExecutorPipeline {
+    private Thread[] threadPool;
+    private List<BlockingQueue<RequestContext>> queues;
+    private Consumer<Collection<RequestContext>> handler = null;
+    private AtomicBoolean isRunning = new AtomicBoolean(true);
+
+    private ExecutorPipeline(int poolSize) {
+      threadPool = new Thread[poolSize];
+      queues = new ArrayList<>(poolSize);
+      for (int i = 0; i < poolSize; ++i) {
+        LinkedBlockingQueue<RequestContext> queue = new LinkedBlockingQueue<>(1000);
+        queues.add(queue);
+        threadPool[i] = new Thread(() -> execute(queue), "OMExecutor-" + i);
+        threadPool[i].start();
+      }
+    }
+    public ExecutorPipeline(int poolSize, Consumer<Collection<RequestContext>> handler) {
+      this(poolSize);
+      this.handler = handler;
+    }
+    public void submit(int idx, RequestContext ctx) throws InterruptedException {
+      if (idx >= threadPool.length) {
+        return;
+      }
+      queues.get(idx).put(ctx);
+    }
+
+    private void execute(BlockingQueue<RequestContext> q) {
+      while (isRunning.get()) {
+        try {
+          List<RequestContext> entries = new LinkedList<>();
+          RequestContext ctx = q.take();
+          entries.add(ctx);
+          q.drainTo(entries);
+          handler.accept(entries);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    }
+  }
+
+  private static String getDistributionKey(OMRequest omRequest, OzoneManager ozoneManager) {
+    OzoneManagerProtocolProtos.Type cmdType = omRequest.getCmdType();
+    OzoneManagerProtocolProtos.KeyArgs keyArgs;
+
+    switch (cmdType) {
+    case CreateVolume:
+      return omRequest.getCreateVolumeRequest().getVolumeInfo().getVolume();
+    case SetVolumeProperty:
+      return omRequest.getSetVolumePropertyRequest().getVolumeName();
+    case DeleteVolume:
+      return omRequest.getDeleteVolumeRequest().getVolumeName();
+    case CreateBucket:
+      return omRequest.getCreateBucketRequest().getBucketInfo().getBucketName();
+    case DeleteBucket:
+      return omRequest.getDeleteBucketRequest().getBucketName();
+    case SetBucketProperty:
+      return omRequest.getSetBucketPropertyRequest().getBucketArgs().getBucketName();
+    case AddAcl:
+      return omRequest.getAddAclRequest().getObj().getPath();
+    case RemoveAcl:
+      return omRequest.getRemoveAclRequest().getObj().getPath();
+    case SetAcl:
+      return omRequest.getSetAclRequest().getObj().getPath();
+    case GetDelegationToken:
+    case CancelDelegationToken:
+    case RenewDelegationToken:
+      return "delegation";
+    case GetS3Secret:
+      return omRequest.getGetS3SecretRequest().getKerberosID();
+    case SetS3Secret:
+      return omRequest.getSetS3SecretRequest().getAccessId();
+    case RevokeS3Secret:
+      return omRequest.getRevokeS3SecretRequest().getKerberosID();
+    case FinalizeUpgrade:
+    case Prepare:
+    case CancelPrepare:
+    case SetRangerServiceVersion:
+    case EchoRPC:
+    case QuotaRepair:
+    case AbortExpiredMultiPartUploads:
+      return "om";
+    case PurgeKeys:
+    case PurgeDirectories:
+    case SnapshotMoveDeletedKeys:
+    case SnapshotPurge:
+    case SetSnapshotProperty:
+    case DeleteOpenKeys:
+    case PersistDb:
+      return "internal";
+    case CreateTenant:
+      return omRequest.getCreateTenantRequest().getVolumeName();
+    case DeleteTenant:
+      return omRequest.getDeleteTenantRequest().getTenantId();
+    case TenantAssignUserAccessId:
+      return omRequest.getTenantAssignUserAccessIdRequest().getTenantId();
+    case TenantRevokeUserAccessId:
+      return omRequest.getTenantRevokeUserAccessIdRequest().getTenantId();
+    case TenantAssignAdmin:
+      return omRequest.getTenantAssignAdminRequest().getTenantId();
+    case TenantRevokeAdmin:
+      return omRequest.getTenantRevokeAdminRequest().getTenantId();
+    case CreateSnapshot:
+      return omRequest.getCreateSnapshotRequest().getBucketName();
+    case DeleteSnapshot:
+      return omRequest.getDeleteSnapshotRequest().getBucketName();
+    case RenameSnapshot:
+      return omRequest.getRenameSnapshotRequest().getBucketName();
+    case RecoverLease:
+      return ozoneManager.getMetadataManager().getOzoneKey(omRequest.getRecoverLeaseRequest().getVolumeName(),
+          omRequest.getRecoverLeaseRequest().getBucketName(),
+          omRequest.getRecoverLeaseRequest().getKeyName());
+    case CreateDirectory:
+      keyArgs = omRequest.getCreateDirectoryRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case CreateFile:
+      keyArgs = omRequest.getCreateFileRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case CreateKey:
+      keyArgs = omRequest.getCreateKeyRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case AllocateBlock:
+      keyArgs = omRequest.getAllocateBlockRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case CommitKey:
+      keyArgs = omRequest.getCommitKeyRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case DeleteKey:
+      keyArgs = omRequest.getDeleteKeyRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case DeleteKeys:
+      OzoneManagerProtocolProtos.DeleteKeyArgs deleteKeyArgs = omRequest.getDeleteKeysRequest().getDeleteKeys();
+      return ozoneManager.getMetadataManager().getOzoneKey(deleteKeyArgs.getVolumeName(),
+          deleteKeyArgs.getBucketName(), "");
+    case RenameKey:
+      keyArgs = omRequest.getRenameKeyRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    case RenameKeys:
+      OzoneManagerProtocolProtos.RenameKeysArgs renameKeysArgs =
+          omRequest.getRenameKeysRequest().getRenameKeysArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(renameKeysArgs.getVolumeName(),
+          renameKeysArgs.getBucketName(), "");
+    case InitiateMultiPartUpload:
+      keyArgs = omRequest.getInitiateMultiPartUploadRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), keyArgs.getKeyName());
+    case CommitMultiPartUpload:
+      keyArgs = omRequest.getCommitMultiPartUploadRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), keyArgs.getKeyName());
+    case AbortMultiPartUpload:
+      keyArgs = omRequest.getAbortMultiPartUploadRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), keyArgs.getKeyName());
+    case CompleteMultiPartUpload:
+      keyArgs = omRequest.getCompleteMultiPartUploadRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), keyArgs.getKeyName());
+    case SetTimes:
+      keyArgs = omRequest.getSetTimesRequest().getKeyArgs();
+      return ozoneManager.getMetadataManager().getOzoneKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+          keyArgs.getKeyName());
+    default:
+      return "";
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.hadoop.hdds.utils.NettyMetrics;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -36,9 +35,8 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.lock.OMLockDetails;
-import org.apache.hadoop.ozone.om.response.DummyOMClientResponse;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -52,8 +50,8 @@ import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
-import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.RaftServer;
@@ -66,14 +64,13 @@ import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.ExitUtils;
-import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.METADATA_ERROR;
-import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 
 /**
  * The OM StateMachine is the state machine for OM Ratis server. It is

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.request.BucketLayoutAwareOMKeyRequestFactory;
+import org.apache.hadoop.ozone.om.request.OMPersistDbRequest;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketDeleteRequest;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketSetOwnerRequest;
@@ -334,6 +335,8 @@ public final class OzoneManagerRatisUtils {
       return new S3ExpiredMultipartUploadsAbortRequest(omRequest);
     case QuotaRepair:
       return new OMQuotaRepairRequest(omRequest);
+    case PersistDb:
+        return new OMPersistDbRequest(omRequest);
     default:
       throw new OMException("Unrecognized write command type request "
           + cmdType, OMException.ResultCodes.INVALID_REQUEST);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.DummyOMClientResponse;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handle OMQuotaRepairRequest Request.
+ */
+public class OMPersistDbRequest extends OMClientRequest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMPersistDbRequest.class);
+
+  public OMPersistDbRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    UserGroupInformation ugi = createUGIForApi();
+    if (ozoneManager.getAclsEnabled() && !ozoneManager.isAdmin(ugi)) {
+      throw new OMException("Access denied for user " + ugi + ". Admin privilege is required.",
+          OMException.ResultCodes.ACCESS_DENIED);
+    }
+    return super.preExecute(ozoneManager);
+  }
+
+  @Override
+  @SuppressWarnings("methodlength")
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, TermIndex termIndex) {
+    OzoneManagerProtocolProtos.OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(getOmRequest());
+    OzoneManagerProtocolProtos.PersistDbRequest dbUpdateRequest = getOmRequest().getPersistDbRequest();
+    LOG.warn("sumit..dbupdate...{}--{}", dbUpdateRequest.getCacheIndex(), termIndex.getIndex());
+
+    try (BatchOperation batchOperation = ozoneManager.getMetadataManager().getStore()
+        .initBatchOperation()) {
+      List<OzoneManagerProtocolProtos.DBTableUpdate> tableUpdatesList = dbUpdateRequest.getTableUpdatesList();
+      for (OzoneManagerProtocolProtos.DBTableUpdate tblUpdates : tableUpdatesList) {
+        Table table = ozoneManager.getMetadataManager().getTable(tblUpdates.getTableName());
+        List<OzoneManagerProtocolProtos.DBTableRecord> recordsList = tblUpdates.getRecordsList();
+        for (OzoneManagerProtocolProtos.DBTableRecord record : recordsList) {
+          if (record.hasValue()) {
+            table.getRawTable().putWithBatch(batchOperation, record.getKey().toByteArray(), record.getValue().toByteArray());
+            // put
+          } else {
+            // delete
+            table.getRawTable().deleteWithBatch(batchOperation, record.getKey().toByteArray());
+          }
+        }
+      }
+      ozoneManager.getMetadataManager().getStore().commitBatchOperation(batchOperation);
+      omResponse.setPersistDbResponse(OzoneManagerProtocolProtos.PersistDbResponse.newBuilder().build());
+    } catch (Exception ex) {
+      LOG.warn("sumit..dbupdate..failed...{}--{}", dbUpdateRequest.getCacheIndex(), termIndex.getIndex());
+      return new DummyOMClientResponse(createErrorOMResponse(omResponse, ex));
+    }
+    LOG.warn("sumit..dbupdate..success...{}--{}", dbUpdateRequest.getCacheIndex(), termIndex.getIndex());
+    OMClientResponse omClientResponse = new DummyOMClientResponse(omResponse.build());
+    return omClientResponse;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
@@ -64,7 +64,6 @@ public class OMPersistDbRequest extends OMClientRequest {
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager, TermIndex termIndex) {
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(getOmRequest());
     OzoneManagerProtocolProtos.PersistDbRequest dbUpdateRequest = getOmRequest().getPersistDbRequest();
-    LOG.warn("sumit..dbupdate...{}--{}", dbUpdateRequest.getCacheIndex(), termIndex.getIndex());
 
     try (BatchOperation batchOperation = ozoneManager.getMetadataManager().getStore()
         .initBatchOperation()) {
@@ -74,13 +73,11 @@ public class OMPersistDbRequest extends OMClientRequest {
         List<OzoneManagerProtocolProtos.DBTableRecord> recordsList = tblUpdates.getRecordsList();
         for (OzoneManagerProtocolProtos.DBTableRecord record : recordsList) {
           if (record.hasValue()) {
-            //LOG.warn("sumit...dbupdate...record...{}-{}", table, record.getKey().toStringUtf8());
+            // put
             table.getRawTable().putWithBatch(batchOperation, record.getKey().toByteArray(),
                 record.getValue().toByteArray());
-            // put
           } else {
             // delete
-            //LOG.warn("sumit...dbupdate...delrecord...{}-{}", table, record.getKey().toStringUtf8());
             table.getRawTable().deleteWithBatch(batchOperation, record.getKey().toByteArray());
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMPersistDbRequest.java
@@ -74,11 +74,13 @@ public class OMPersistDbRequest extends OMClientRequest {
         List<OzoneManagerProtocolProtos.DBTableRecord> recordsList = tblUpdates.getRecordsList();
         for (OzoneManagerProtocolProtos.DBTableRecord record : recordsList) {
           if (record.hasValue()) {
+            //LOG.warn("sumit...dbupdate...record...{}-{}", table, record.getKey().toStringUtf8());
             table.getRawTable().putWithBatch(batchOperation, record.getKey().toByteArray(),
                 record.getValue().toByteArray());
             // put
           } else {
             // delete
+            //LOG.warn("sumit...dbupdate...delrecord...{}-{}", table, record.getKey().toStringUtf8());
             table.getRawTable().deleteWithBatch(batchOperation, record.getKey().toByteArray());
           }
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -251,7 +251,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements OzoneManagerP
    */
   private OMResponse submitRequestToRatis(OMRequest request)
       throws ServiceException {
-    return omRatisServer.submitRequest(request);
+    return omRatisServer.submitRequest(request, null);
   }
 
   private OMResponse submitReadRequestToOM(OMRequest request)


### PR DESCRIPTION
## What changes were proposed in this pull request?

basic flow is implemented where execution is done before and only db update is submitted via raits to all OM.

```
1. UpgradePrepare have impact of termIndex and doubleBuffer -- TO DO
2. OMStateMachine need not have startTransaction, preAppend -- May not require fix, no impact
3. Need remove double doubleBuffer -- Done (code cleanup is pending)
4. To work with WAL removal with using Raft Log as recovery -- WAL flush is disabled, need go with config based solution. No recon impact.
5. Some TODO for executor for throtlling, db error, sync error
6. cache removal for tables (earlier based on annotation) -- Done (code cleanup for annotations if required)
7. cache reversal on db update failure on distributed node ...DONE

6. Audit log will be at Leader only
7. raft log track for request -- not present -- add caller operation and audit log for db sync ??
8. metrics update on follower node for operation -- now not present
9. performance optimization / verification -- Shared below

with this mechanism, lot of failure testcase needs remove / change.
```

Further, `Request like related to snapshot` need handling with distributed execution, like create / delete snapshot is over local filesystem. This is `pending`.

## What is the link to the Apache JIRA

NA

## How was this patch tested?

- basic verify with create volume, bucket and file working

Performance test:
As comparision below, seems approx 50% improvement in response at present.

1. Without change:
```
-- Timers ----------------------------------------------------------------------
key-read-write-list
             count = 396996
         mean rate = 336.06 calls/second
     1-minute rate = 1.08 calls/second
     5-minute rate = 133.94 calls/second
    15-minute rate = 212.31 calls/second
               min = 8.78 milliseconds
               max = 356856.71 milliseconds
              mean = 289769.61 milliseconds
            stddev = 139418.19 milliseconds
            median = 356854.29 milliseconds
              75% <= 356856.19 milliseconds
              95% <= 356856.71 milliseconds
              98% <= 356856.71 milliseconds
              99% <= 356856.71 milliseconds
            99.9% <= 356856.71 milliseconds


Total execution time (sec): 1182
Failures: 10
Successful executions: 396986
Expected 1000000 --number-of-tests objects!, successfully executed 396986
```

2. With Change (new flow):

```
-- Timers ----------------------------------------------------------------------
key-read-write-list
             count = 518958
         mean rate = 593.01 calls/second
     1-minute rate = 4.22 calls/second
     5-minute rate = 276.52 calls/second
    15-minute rate = 363.95 calls/second
               min = 5.60 milliseconds
               max = 323485.91 milliseconds
              mean = 210108.16 milliseconds
            stddev = 146053.50 milliseconds
            median = 305047.34 milliseconds
              75% <= 314279.83 milliseconds
              95% <= 323485.91 milliseconds
              98% <= 323485.91 milliseconds
              99% <= 323485.91 milliseconds
            99.9% <= 323485.91 milliseconds


Total execution time (sec): 876
Failures: 10
Successful executions: 518948
Expected 1000000 --number-of-tests objects!, successfully executed 518948
```